### PR TITLE
st1 [1642][IMP] website_auth_view_mi7: add signin bottom text

### DIFF
--- a/website_auth_view_mi7/__manifest__.py
+++ b/website_auth_view_mi7/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "LGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "depends": ["auth_signup", "website"],
     "data": ["views/templates.xml", "views/website_config_settings_views.xml"],
     "installable": True,

--- a/website_auth_view_mi7/i18n/ja.po
+++ b/website_auth_view_mi7/i18n/ja.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-07 02:23+0000\n"
-"PO-Revision-Date: 2020-10-07 02:23+0000\n"
+"POT-Creation-Date: 2021-02-10 13:55+0000\n"
+"PO-Revision-Date: 2021-02-10 13:55+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -27,15 +27,16 @@ msgid "Login Page Header Text"
 msgstr "ログインページヘッダーテキスト"
 
 #. module: website_auth_view_mi7
+#: model:ir.model.fields,field_description:website_auth_view_mi7.field_website_config_settings_login_page_signin_bottom_text
+#: model:ir.model.fields,field_description:website_auth_view_mi7.field_website_login_page_signin_bottom_text
+msgid "Login Page Sign-in Bottom Text"
+msgstr "ログインページログイン下部テキスト"
+
+#. module: website_auth_view_mi7
 #: model:ir.model.fields,field_description:website_auth_view_mi7.field_website_config_settings_login_page_signup_text
 #: model:ir.model.fields,field_description:website_auth_view_mi7.field_website_login_page_signup_text
 msgid "Login Page User Register Text"
 msgstr "ログインページユーザ登録テキスト"
-
-#. module: website_auth_view_mi7
-#: model:ir.ui.view,arch_db:website_auth_view_mi7.signup
-msgid "Membership Terms and Conditions"
-msgstr "会員規約"
 
 #. module: website_auth_view_mi7
 #: model:ir.ui.view,arch_db:website_auth_view_mi7.custom_login_layout

--- a/website_auth_view_mi7/models/website.py
+++ b/website_auth_view_mi7/models/website.py
@@ -11,6 +11,9 @@ class Website(models.Model):
     login_page_header_text = fields.Html(
         "Login Page Header Text", translate=True, sanitize=False
     )
+    login_page_signin_bottom_text = fields.Html(
+        "Login Page Sign-in Bottom Text", translate=True, sanitize=False
+    )
     login_page_signup_text = fields.Html(
         "Login Page User Register Text", translate=True, sanitize=False
     )

--- a/website_auth_view_mi7/models/website_config_settings.py
+++ b/website_auth_view_mi7/models/website_config_settings.py
@@ -12,7 +12,8 @@ class WebsiteConfigSettings(models.TransientModel):
         "Login Page Header Text", related="website_id.login_page_header_text"
     )
     login_page_signin_bottom_text = fields.Html(
-        "Login Page Sign-in Bottom Text", related="website_id.login_page_signin_bottom_text"
+        "Login Page Sign-in Bottom Text",
+        related="website_id.login_page_signin_bottom_text",
     )
     login_page_signup_text = fields.Html(
         "Login Page User Register Text", related="website_id.login_page_signup_text"

--- a/website_auth_view_mi7/models/website_config_settings.py
+++ b/website_auth_view_mi7/models/website_config_settings.py
@@ -11,6 +11,9 @@ class WebsiteConfigSettings(models.TransientModel):
     login_page_header_text = fields.Html(
         "Login Page Header Text", related="website_id.login_page_header_text"
     )
+    login_page_signin_bottom_text = fields.Html(
+        "Login Page Sign-in Bottom Text", related="website_id.login_page_signin_bottom_text"
+    )
     login_page_signup_text = fields.Html(
         "Login Page User Register Text", related="website_id.login_page_signup_text"
     )

--- a/website_auth_view_mi7/views/templates.xml
+++ b/website_auth_view_mi7/views/templates.xml
@@ -113,6 +113,7 @@
                 t-attf-href="/web/reset_password?{{ keep_query() }}"
                 class="btn btn-link"
             >Reset Password</a>
+            <t t-raw="website.login_page_signin_bottom_text" />
         </xpath>
     </template>
     <!-- QRTL Edit: Adjust the class of the login button div -->

--- a/website_auth_view_mi7/views/website_config_settings_views.xml
+++ b/website_auth_view_mi7/views/website_config_settings_views.xml
@@ -8,6 +8,7 @@
             <group name="social" position="before">
                 <group name="auth_view" string="Signup/Login Pages Texts">
                     <field name="login_page_header_text" widget="html" />
+                    <field name="login_page_signin_bottom_text" widget="html" />
                     <field name="login_page_signup_text" widget="html" />
                     <field name="signup_page_header_text" widget="html" />
                     <field name="signup_page_terms_text" widget="html" />


### PR DESCRIPTION
[1642](https://www.quartile.co/web#view_type=form&model=project.task&id=1642&active_id=1642&menu_id=)

Couldn't get around to generate the translation string for "Reset Password" part for an unknown reason.  We may ask the customer to just accept how it is now for this part, or get rid of the link from the template and embed one in the newly added field.