### PR TITLE
st1[1691][IMP] account_invoice_validate_send_email: add out_refund in action_send

### DIFF
--- a/account_invoice_validate_send_email/models/account_invoice.py
+++ b/account_invoice_validate_send_email/models/account_invoice.py
@@ -88,7 +88,7 @@ class AccountInvoice(models.Model):
     def action_send(self):
         # send notification email for follower
         self.ensure_one()
-        if self.type == "out_invoice" or "out_refund":
+        if self.type == "out_invoice" or self.type == "out_refund":
             email_act = self.get_mail_compose_message()
             if email_act and email_act.get("context"):
                 email_ctx = email_act["context"]

--- a/account_invoice_validate_send_email/models/account_invoice.py
+++ b/account_invoice_validate_send_email/models/account_invoice.py
@@ -88,7 +88,7 @@ class AccountInvoice(models.Model):
     def action_send(self):
         # send notification email for follower
         self.ensure_one()
-        if self.type == "out_invoice" or self.type == "out_refund":
+        if self.type in ("out_invoice", "out_refund"):
             email_act = self.get_mail_compose_message()
             if email_act and email_act.get("context"):
                 email_ctx = email_act["context"]

--- a/account_invoice_validate_send_email/models/account_invoice.py
+++ b/account_invoice_validate_send_email/models/account_invoice.py
@@ -88,7 +88,7 @@ class AccountInvoice(models.Model):
     def action_send(self):
         # send notification email for follower
         self.ensure_one()
-        if self.type == "out_invoice":
+        if self.type == "out_invoice" or "out_refund":
             email_act = self.get_mail_compose_message()
             if email_act and email_act.get("context"):
                 email_ctx = email_act["context"]

--- a/account_invoice_validate_send_email/views/stock_picking_views.xml
+++ b/account_invoice_validate_send_email/views/stock_picking_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field
                     name="not_send_invoice"
-                    attrs="{'invisible':[('sale_id','==',Null)]}"
+                    attrs="{'invisible':[('sale_id','=',False)]}"
                 />
             </xpath>
         </field>

--- a/account_invoice_validate_send_email/views/stock_picking_views.xml
+++ b/account_invoice_validate_send_email/views/stock_picking_views.xml
@@ -8,7 +8,7 @@
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field
                     name="not_send_invoice"
-                    attrs="{'invisible':[('picking_type_code','!=','outgoing')]}"
+                    attrs="{'invisible':[('sale_id','==',Null)]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
[1691](https://www.quartile.co/web?#id=1691&action=771&model=project.task&view_type=form&menu_id=505)

追加機能：
受注配送検証時の自動メール送信の対象に「返品」も含める。

検証1：追加機能の動作確認
アプリ：販売
2. B2Bで受注したオーダーから「返品伝票」をクリックして返品見積を作成
3. 受注確認をクリック
4. 配送をクリック
5. 請求書が自動生成、検証をクリック
→メール送信を確認。

検証2：返品に関わる入庫が請求自動送信の対象になっている。
アプリ：在庫

1. ダッシュボードの入荷タブに移動
2. 今回のオーダ番号(SO21-XXXXX)を参照している入庫情報をクリック
3. 「請求書自動送信対象外」の項目があり、チェックが入っていないことを確認