### PR TITLE
st1 [1691][IMP] account_invoice_validate_send_email

### DIFF
--- a/account_invoice_validate_send_email/models/account_invoice.py
+++ b/account_invoice_validate_send_email/models/account_invoice.py
@@ -70,13 +70,15 @@ class AccountInvoice(models.Model):
                 continue
             term = invoice.payment_term_id
             pickings = invoice.picking_ids
+            # Supposedly 返品伝票
             if not pickings:
                 orders = invoice.invoice_line_ids.mapped("sale_line_ids").mapped(
                     "order_id"
                 )
-                pickings = self.env["stock.picking"].search(
-                    [("sale_id", "in", orders.ids)]
-                )
+                if orders:
+                    pickings = self.env["stock.picking"].search(
+                        [("sale_id", "in", orders.ids)]
+                    )
             if not pickings:
                 continue
             if (

--- a/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
+++ b/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
@@ -10,11 +10,6 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestAccountInvoiceValidateSendEmail, cls).setUpClass()
-        picking = cls.env["stock.picking"].create(
-            {
-            'picking_type_id': cls.env.ref('stock.picking_type_out'),
-            }
-        )
         account_rev = cls.env["account.account"].create(
             {
                 "code": "X2020",
@@ -49,13 +44,35 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
                 # "not_send_invoice": True,
             }
         )
+        sale_order =cls.env[sale.order].create({
+            'partner_id': partner.id,
+            'partner_invoice_id': partner.id,
+            'partner_shipping_id': partner.id,
+            'order_line': [
+                (0, 0, {
+                    'name': "name1", 'product_id': prod_order.id,
+                    'product_uom_qty': 2, 'product_uom': prod_order.uom_id.id,
+                    'price_unit': prod_order.list_price
+                }),
+                (0, 0, {
+                    'name': "name2", 'product_id': prod_del.id,
+                    'product_uom_qty': 2, 'product_uom': prod_del.uom_id.id,
+                    'price_unit': prod_del.list_price
+                }),
+                (0, 0, {
+                    'name': "name3", 'product_id': serv_order.id,
+                    'product_uom_qty': 2, 'product_uom': serv_order.uom_id.id,
+                    'price_unit': serv_order.list_price
+                }),
+            ],
+            'picking_policy': 'direct',
+        })
         cls.invoice = cls.env["account.invoice"].create(
             {
                 "origin": "Test Invoice",
                 "type": "out_invoice",
                 "partner_id": partner.id,
                 "journal_id": journal.id,
-                "picking_ids": picking.id,
             }
         )
         cls.env["account.invoice.line"].create(
@@ -65,6 +82,7 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
                 "price_unit": 100,
                 "quantity": 1,
                 "invoice_id": cls.invoice.id,
+                "sale_line_ids":sale_order.mapped("order_line"),
             }
         )
         # Remove report template from the email template to lighten the test load.

--- a/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
+++ b/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
@@ -43,8 +43,12 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
                 # "not_send_invoice": True,
             }
         )
-        location = cls.env["stock.location"].search([("usage", "=", "production")])
-        picking_type = cls.env["stock.picking.type"].search([("code", "=", "incoming")])
+        location = cls.env["stock.location"].search(
+            [("usage", "=", "production")], limit=1
+        )
+        picking_type = cls.env["stock.picking.type"].search(
+            [("code", "=", "outgoing")], limit=1
+        )
         picking = cls.env["stock.picking"].create(
             {
                 "partner_id": partner.id,

--- a/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
+++ b/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
@@ -43,11 +43,12 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
                 # "not_send_invoice": True,
             }
         )
-        cls.sale_order = cls.env["sale.order"].create({
-            'partner_id': partner.id,
-            'partner_invoice_id': partner.id,
-            'partner_shipping_id': partner.id,
-            'picking_policy': 'direct',
+        cls.sale_order = cls.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "partner_invoice_id": partner.id,
+                "partner_shipping_id": partner.id,
+                "picking_policy": "direct",
             }
         )
         cls.invoice = cls.env["account.invoice"].create(

--- a/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
+++ b/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
@@ -6,9 +6,15 @@ from odoo.tests.common import SavepointCase
 
 
 class TestAccountInvoiceValidateSendEmail(SavepointCase):
+    post_install = True
     @classmethod
     def setUpClass(cls):
         super(TestAccountInvoiceValidateSendEmail, cls).setUpClass()
+        picking = cls.env["stock.picking"].create(
+            {
+            'picking_type_id': cls.env.ref('stock.picking_type_out'),
+            }
+        )
         account_rev = cls.env["account.account"].create(
             {
                 "code": "X2020",
@@ -49,6 +55,7 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
                 "type": "out_invoice",
                 "partner_id": partner.id,
                 "journal_id": journal.id,
+                "picking_ids": picking.id,
             }
         )
         cls.env["account.invoice.line"].create(

--- a/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
+++ b/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
@@ -57,6 +57,7 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
                 "partner_id": partner.id,
                 "payment_term_id": cls.payment_term.id,
                 "workflow_process_id": cls.workflow.id,
+                "picking_policy": "direct",
             }
         )
         cls.env["sale.order.line"].create(

--- a/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
+++ b/account_invoice_validate_send_email/tests/test_account_invoice_validate_send_email.py
@@ -9,17 +9,17 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestAccountInvoiceValidateSendEmail, cls).setUpClass()
-        account_rev = cls.env["account.account"].create(
+        cls.env["account.journal"].create(
+            {"name": "Sale Journal - Test", "code": "STSJ", "type": "sale"}
+        )
+        acc_revenue = cls.env["account.account"].create(
             {
                 "code": "X2020",
                 "name": "Sales Test",
                 "user_type_id": cls.env.ref("account.data_account_type_revenue").id,
             }
         )
-        journal = cls.env["account.journal"].create(
-            {"name": "Sale Journal - Test", "code": "STSJ", "type": "sale"}
-        )
-        receivable_id = cls.env["account.account"].create(
+        acc_receivable = cls.env["account.account"].create(
             {
                 "code": "X4040",
                 "name": "Debtors Test",
@@ -31,48 +31,39 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
             {
                 "name": "Test Partner",
                 "email": "test01@gmail.com",
-                "property_account_receivable_id": receivable_id,
+                "property_account_receivable_id": acc_receivable.id,
             }
         )
         cls.workflow = cls.env["sale.workflow.process"].create(
-            {"name": "Send Invoice Test", "send_invoice": True}
+            {
+                "name": "Send Invoice Test",
+                "create_invoice": True,
+                "validate_invoice": True,
+            }
         )
         cls.payment_term = cls.env["account.payment.term"].create(
+            {"name": "Immediate Payment"}
+        )
+        cls.product1 = cls.env["product.product"].create(
             {
-                "name": "Immediate Payment",
-                # "not_send_invoice": True,
+                "name": "test product",
+                "type": "consu",
+                "invoice_policy": "delivery",
+                "property_account_income_id": acc_revenue.id,
             }
         )
-        location = cls.env["stock.location"].search(
-            [("usage", "=", "production")], limit=1
-        )
-        picking_type = cls.env["stock.picking.type"].search(
-            [("code", "=", "outgoing")], limit=1
-        )
-        picking = cls.env["stock.picking"].create(
+        cls.order = cls.env["sale.order"].create(
             {
                 "partner_id": partner.id,
-                "location_id": location.id,
-                "picking_type_id": picking_type.id,
-                "location_dest_id": location.id,
+                "payment_term_id": cls.payment_term.id,
+                "workflow_process_id": cls.workflow.id,
             }
         )
-
-        cls.invoice = cls.env["account.invoice"].create(
+        cls.env["sale.order.line"].create(
             {
-                "origin": "Test Invoice",
-                "type": "out_invoice",
-                "partner_id": partner.id,
-                "journal_id": journal.id,
-            }
-        )
-        cls.env["account.invoice.line"].create(
-            {
-                "name": "Test 01",
-                "account_id": account_rev.id,
-                "price_unit": 100,
-                "quantity": 1,
-                "invoice_id": cls.invoice.id,
+                "order_id": cls.order.id,
+                "product_id": cls.product1.id,
+                "price_unit": 10.0,
             }
         )
         # Remove report template from the email template to lighten the test load.
@@ -80,35 +71,80 @@ class TestAccountInvoiceValidateSendEmail(SavepointCase):
             "account_invoice_validate_send_email.email_template_customer_invoice_validated"
         )
         template.report_template = False
-        cls.invoice.company_id.invoice_mail_template_id = template.id
-        cls.invoice.picking_ids = [picking.id]
+        company = cls.env.ref("base.main_company")
+        company.invoice_mail_template_id = template.id
 
-    def test_01_validate_invoice_no_workflow(self):
-        # Without workflow
-        self.assertEqual(self.invoice.invoice_sent, False)
-        self.invoice.sudo().action_invoice_open()
-        self.assertEqual(self.invoice.invoice_sent, False)
+    def test_01_validate_invoice_workflow_no_send(self):
+        # Workflow send_invoice is false
+        self.order.action_confirm()
+        picking = self.order.picking_ids
+        picking.validate_picking()
+        self.env["automatic.workflow.job"].run()
+        invoice = self.order.invoice_ids
+        self.assertEqual(invoice.invoice_sent, False)
 
-    def test_02_validate_invoice_workflow_no_term(self):
-        # With workflow, without payment term
-        self.assertEqual(self.invoice.invoice_sent, False)
-        self.invoice.workflow_process_id = self.workflow
-        self.invoice.sudo().action_invoice_open()
-        self.assertEqual(self.invoice.invoice_sent, True)
+    def test_02_validate_invoice_workflow_send(self):
+        # Workflow send_invoice is true
+        self.workflow.send_invoice = True
+        self.order.action_confirm()
+        picking = self.order.picking_ids
+        picking.validate_picking()
+        self.env["automatic.workflow.job"].run()
+        invoice = self.order.invoice_ids
+        self.assertEqual(invoice.invoice_sent, True)
 
-    def test_03_validate_invoice_workflow_term_not_send(self):
-        # With workflow, with payment term (no_send_invoice is true)
-        self.assertEqual(self.invoice.invoice_sent, False)
-        self.invoice.workflow_process_id = self.workflow
+    def test_03_validate_invoice_payment_term_no_send(self):
+        # Workflow send_invoice is true, payment term not_send_invoice is true
+        self.workflow.send_invoice = True
         self.payment_term.not_send_invoice = True
-        self.invoice.payment_term_id = self.payment_term
-        self.invoice.sudo().action_invoice_open()
-        self.assertEqual(self.invoice.invoice_sent, False)
+        self.order.action_confirm()
+        picking = self.order.picking_ids
+        picking.validate_picking()
+        self.env["automatic.workflow.job"].run()
+        invoice = self.order.invoice_ids
+        self.assertEqual(invoice.invoice_sent, False)
 
-    def test_04_validate_invoice_workflow_term_send(self):
-        # With workflow, with payment term (no_send_invoice is false)
-        self.assertEqual(self.invoice.invoice_sent, False)
-        self.invoice.workflow_process_id = self.workflow
-        self.invoice.payment_term_id = self.payment_term
-        self.invoice.sudo().action_invoice_open()
-        self.assertEqual(self.invoice.invoice_sent, True)
+    def test_04_validate_invoice_picking_no_send(self):
+        # Workflow send_invoice is true, picking not_send_invoice is true
+        self.workflow.send_invoice = True
+        self.order.action_confirm()
+        picking = self.order.picking_ids
+        picking.not_send_invoice = True
+        picking.validate_picking()
+        self.env["automatic.workflow.job"].run()
+        invoice = self.order.invoice_ids
+        self.assertEqual(invoice.picking_ids, picking)
+        self.assertEqual(invoice.invoice_sent, False)
+
+    def test_05_validate_invoice_no_picking_link(self):
+        # Workflow send_invoice is true, picking not_send_invoice is false
+        self.workflow.send_invoice = True
+        # No automatic processing of invoice validation
+        self.workflow.validate_invoice = False
+        self.order.action_confirm()
+        picking = self.order.picking_ids
+        picking.validate_picking()
+        self.env["automatic.workflow.job"].run()
+        invoice = self.order.invoice_ids
+        # Remove the direct link to the picking
+        invoice.picking_ids = False
+        self.assertEqual(invoice.picking_ids, self.env["stock.picking"].browse())
+        invoice.action_invoice_open()
+        self.assertEqual(invoice.invoice_sent, True)
+
+    def test_06_validate_invoice_no_picking_link(self):
+        # Workflow send_invoice is true, picking not_send_invoice is true
+        self.workflow.send_invoice = True
+        # No automatic processing of invoice validation
+        self.workflow.validate_invoice = False
+        self.order.action_confirm()
+        picking = self.order.picking_ids
+        picking.not_send_invoice = True
+        picking.validate_picking()
+        self.env["automatic.workflow.job"].run()
+        invoice = self.order.invoice_ids
+        # Remove the direct link to the picking
+        invoice.picking_ids = False
+        self.assertEqual(invoice.picking_ids, self.env["stock.picking"].browse())
+        invoice.action_invoice_open()
+        self.assertEqual(invoice.invoice_sent, False)


### PR DESCRIPTION
[1691](https://www.quartile.co/web#id=1691&action=771&model=project.task&view_type=form&menu_id=505)

Previous PR
#64 

検証内容：
請求書自動送信対象外チェックについて、分納に対応。
以下を受注・返品の両方で検証。

- 請求書行が2行ある受注を作成。発送を1行ずつに分けて検証。
1行目の発送では請求書自動送信対象外にチェック、2行目の発送にはチェックを入れずに検証をクリック。
1行目発送の請求書→メール送信されず。
2行目発送の請求書→メールが送信。