### PR TITLE
st1 [1691] [FIX] mail_compose_message_reply_to;add_depends

### DIFF
--- a/mail_compose_message_reply_to/__manifest__.py
+++ b/mail_compose_message_reply_to/__manifest__.py
@@ -8,5 +8,6 @@
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
     "version": "10.0.1.0.0",
+    "depends": ["mail"],
     "installable": True,
 }


### PR DESCRIPTION
[1691](https://www.quartile.co/web#id=1691&model=project.task&view_type=form&menu_id=)
"depends" are added into __manifest__.py to avoid/fix bug.