### PR TITLE
st1 [2023][FIX] account_invoice_validate_send_email: _compute_carrier_info()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ exclude: |
   (LICENSE.*|COPYING.*)|
   ^\.travis\.yml$
 default_language_version:
-  python: python3
+  python: python3.6
 repos:
   - repo: https://github.com/psf/black
     rev: 19.10b0

--- a/account_invoice_validate_send_email/data/email_templates.xml
+++ b/account_invoice_validate_send_email/data/email_templates.xml
@@ -39,17 +39,17 @@
 <p>
 ${object.number or 'N/A'}
 </p>
-% if object.carrier_info_name
+% if object.carrier_info_name:
 <p>
 配送業者：${object.carrier_info_name}
 </p>
 % endif
-% if object.carrier_tracking_refs
+% if object.carrier_tracking_refs:
 <p>
 送り状お問い合わせNo：${object.carrier_tracking_refs}
 </p>
 % endif
-% if object.carrier_tracking_url
+% if object.carrier_tracking_url:
 <p>
 配送状況を配達業者のWebサイトでご確認頂けます。<br>
 ${object.carrier_tracking_url}

--- a/account_invoice_validate_send_email/models/account_invoice.py
+++ b/account_invoice_validate_send_email/models/account_invoice.py
@@ -23,8 +23,8 @@ class AccountInvoice(models.Model):
         help="Delivery slip numbers taken from the linked deliveries.",
         compute="_compute_carrier_info",
     )
-    carrier_info_name = fields.Char(compute="_compute_carrier_info",)
-    carrier_tracking_url = fields.Char(compute="_compute_carrier_info",)
+    carrier_info_name = fields.Char(compute="_compute_carrier_info")
+    carrier_tracking_url = fields.Char(compute="_compute_carrier_info")
 
     def _get_mail_template(self):
         self.ensure_one()
@@ -124,9 +124,14 @@ class AccountInvoice(models.Model):
     def _compute_carrier_info(self):
         for invoice in self:
             carrier_recs = invoice.picking_ids.mapped("carrier_info_id")
-            tracking_refs = invoice.picking_ids.mapped("carrier_tracking_ref")
-            invoice.carrier_info_name = ", ".join(x.name for x in carrier_recs)
-            invoice.carrier_tracking_url = ", ".join(
-                x.tracking_url for x in carrier_recs
-            )
-            invoice.carrier_tracking_refs = ", ".join(tracking_refs)
+            if carrier_recs:
+                invoice.carrier_info_name = ", ".join(x.name for x in carrier_recs)
+                invoice.carrier_tracking_url = ", ".join(
+                    x.tracking_url for x in carrier_recs
+                )
+            tracking_refs = []
+            for pick in invoice.picking_ids:
+                if pick.carrier_tracking_ref:
+                    tracking_refs.append(pick.carrier_tracking_ref)
+            if tracking_refs:
+                invoice.carrier_tracking_refs = ", ".join(tracking_refs)

--- a/stock_carrier_info/__manifest__.py
+++ b/stock_carrier_info/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co/",
-    "depends": ["sale_stock"],
+    "depends": ["delivery"],
     "data": [
         "security/ir.model.access.csv",
         "views/stock_carrier_info_views.xml",


### PR DESCRIPTION
[2023](https://www.quartile.co/web#id=2023&action=771&model=project.task&view_type=form&menu_id=505)

Before this fix, the computation of the values would fail when there is no corresponding
carrier info records or tracking refs from the linked pickings, which would make it
impossible to validate the invoice.
