### PR TITLE
st1 [1782][IMP] account_invoice_validate_send_email

### DIFF
--- a/account_invoice_validate_send_email/__manifest__.py
+++ b/account_invoice_validate_send_email/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "AGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.2.0",
     "depends": [
         "pro_mi7_account",
         "sale_automatic_workflow",
@@ -20,6 +20,7 @@
         "views/account_invoice_view.xml",
         "views/account_payment_term_views.xml",
         "views/sale_workflow_process_views.xml",
+        "views/stock_carrier_info_views.xml",
         "views/stock_picking_views.xml",
         "views/res_company_views.xml",
     ],

--- a/account_invoice_validate_send_email/i18n/ja.po
+++ b/account_invoice_validate_send_email/i18n/ja.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-30 05:03+0000\n"
-"PO-Revision-Date: 2021-09-30 05:03+0000\n"
+"POT-Creation-Date: 2021-11-03 08:56+0000\n"
+"PO-Revision-Date: 2021-11-03 08:56+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,87 +16,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: account_invoice_validate_send_email
-#: model:mail.template,body_html:account_invoice_validate_send_email.email_template_customer_invoice_validated
-msgid "\n"
-"<p>${object.partner_id.name}\n"
-"% if object.partner_id.parent_id:\n"
-"    (<i>${object.partner_id.parent_id.name}</i>)\n"
-"% endif\n"
-"様</p>\n"
-"<p>\n"
-"お世話になっております。<br>\n"
-"以下のとおり、請求書を送付いたしますので、ご査収の程よろしくお願いいたします。\n"
-"</p>\n"
-"<p>\n"
-"<strong>${object.number or 'N/A'}</strong>\n"
-"</p>\n"
-"% if object.carrier_info_name\n"
-"<p>\n"
-"<strong>配送業者：${object.carrier_info_name}</strong>\n"
-"<br>\n"
-"% endif\n"
-"<br>\n"
-"% if object.carrier_tracking_refs\n"
-"<br>\n"
-"<strong>送り状お問い合わせNo：${object.carrier_tracking_refs}</strong>\n"
-"<br>\n"
-"% endif\n"
-"% if object.carrier_info_url\n"
-"<strong>配送状況を配達業者のWebサイトでご確認頂けます。\n"
-"<br>\n"
-"${object.carrier_info_url}}</strong>\n"
-"<br>\n"
-"\n"
-"</p>\n"
-"% endif\n"
-"<p>\n"
-"宜しくお願い致します。\n"
-"</p>\n"
-"<p>\n"
-"${object.company_id.name}<br>\n"
-"</p>\n"
-"\n"
-"        "
-msgstr "\n"
-"<p>${object.partner_id.name}\n"
-"% if object.partner_id.parent_id:\n"
-"    (<i>${object.partner_id.parent_id.name}</i>)\n"
-"% endif\n"
-"様</p>\n"
-"<p>\n"
-"お世話になっております。<br>\n"
-"以下のとおり、請求書を送付いたしますので、ご査収の程よろしくお願いいたします。\n"
-"</p>\n"
-"<p>\n"
-"<strong>${object.number or 'N/A'}</strong>\n"
-"</p>\n"
-"% if object.carrier_info_name\n"
-"<p>\n"
-"<strong>配送業者：${object.carrier_info_name}</strong>\n"
-"<br>\n"
-"% endif\n"
-"<br>\n"
-"% if object.carrier_tracking_refs\n"
-"<br>\n"
-"<strong>送り状お問い合わせNo：${object.carrier_tracking_refs}</strong>\n"
-"<br>\n"
-"% endif\n"
-"% if object.carrier_info_url\n"
-"<strong>配送状況を配達業者のWebサイトでご確認頂けます。\n"
-"<br>\n"
-"${object.carrier_info_url}}</strong>\n"
-"<br>\n"
-"\n"
-"</p>\n"
-"% endif\n"
-"<p>\n"
-"宜しくお願い致します。\n"
-"</p>\n"
-"<p>\n"
-"${object.company_id.name}<br>\n"
-"</p>\n"
-"\n"
-"        "
+#: model:ir.model.fields,field_description:account_invoice_validate_send_email.field_account_invoice_carrier_info_name
+msgid "Carrier info name"
+msgstr "Carrier info name"
+
+#. module: account_invoice_validate_send_email
+#: model:ir.model.fields,field_description:account_invoice_validate_send_email.field_account_invoice_carrier_tracking_url
+msgid "Carrier tracking url"
+msgstr "Carrier tracking url"
 
 #. module: account_invoice_validate_send_email
 #: model:ir.model,name:account_invoice_validate_send_email.model_res_company
@@ -104,29 +31,19 @@ msgid "Companies"
 msgstr "会社"
 
 #. module: account_invoice_validate_send_email
-#: model:ir.model.fields,help:account_invoice_validate_send_email.field_account_invoice_carrier_info_name
-msgid "Delivery Carrier Information for send a e-mail to customer."
-msgstr "顧客へのメール送信のための運送会社情報。"
-
-#. module: account_invoice_validate_send_email
-#: model:ir.model.fields,field_description:account_invoice_validate_send_email.field_account_invoice_carrier_info_name
-msgid "Delivery Carrier Name"
-msgstr "運送会社名"
-
-#. module: account_invoice_validate_send_email
-#: model:ir.model.fields,field_description:account_invoice_validate_send_email.field_account_invoice_carrier_info_url
-msgid "Delivery Carrier URL"
-msgstr "運送会社URL"
-
-#. module: account_invoice_validate_send_email
-#: model:ir.model.fields,help:account_invoice_validate_send_email.field_account_invoice_carrier_info_url
-msgid "Delivery Carrier's URL for tracking."
-msgstr "運送会社 追跡用URL"
-
-#. module: account_invoice_validate_send_email
 #: model:ir.model.fields,help:account_invoice_validate_send_email.field_account_invoice_carrier_tracking_refs
 msgid "Delivery slip numbers taken from the linked deliveries."
 msgstr "運送会社から取得された追跡番号です。"
+
+#. module: account_invoice_validate_send_email
+#: model:ir.model.fields,field_description:account_invoice_validate_send_email.field_stock_carrier_info_is_dummy
+msgid "Dummy Carrier"
+msgstr "ダミー運送会社"
+
+#. module: account_invoice_validate_send_email
+#: model:ir.model.fields,help:account_invoice_validate_send_email.field_stock_carrier_info_is_dummy
+msgid "If selected, the carrier info will be ignored in email content preparation at the invoice validation."
+msgstr "選択された場合、運送会社情報は請求書検証時のEメール内容生成にて無視されます。"
 
 #. module: account_invoice_validate_send_email
 #: model:ir.model,name:account_invoice_validate_send_email.model_account_invoice
@@ -162,13 +79,18 @@ msgstr "支払条件"
 #. module: account_invoice_validate_send_email
 #: model:ir.model,name:account_invoice_validate_send_email.model_sale_workflow_process
 msgid "Sale Workflow Process"
-msgstr "販売ワークフロープロセス"
+msgstr "Sale Workflow Process"
 
 #. module: account_invoice_validate_send_email
 #: model:ir.model.fields,field_description:account_invoice_validate_send_email.field_account_invoice_send_invoice
 #: model:ir.model.fields,field_description:account_invoice_validate_send_email.field_sale_workflow_process_send_invoice
 msgid "Send Invoice upon Validation"
 msgstr "検証時に請求書送信"
+
+#. module: account_invoice_validate_send_email
+#: model:ir.model,name:account_invoice_validate_send_email.model_stock_carrier_info
+msgid "Stock Carrier Info"
+msgstr "運送会社情報"
 
 #. module: account_invoice_validate_send_email
 #: model:ir.model.fields,field_description:account_invoice_validate_send_email.field_account_invoice_carrier_tracking_refs

--- a/account_invoice_validate_send_email/models/__init__.py
+++ b/account_invoice_validate_send_email/models/__init__.py
@@ -2,6 +2,7 @@
 
 from . import account_invoice
 from . import account_payment_term
+from . import stock_carrier_info
 from . import sale_workflow_process
 from . import stock_picking
 from . import res_company

--- a/account_invoice_validate_send_email/models/account_invoice.py
+++ b/account_invoice_validate_send_email/models/account_invoice.py
@@ -123,7 +123,9 @@ class AccountInvoice(models.Model):
     @api.multi
     def _compute_carrier_info(self):
         for invoice in self:
-            carrier_recs = invoice.picking_ids.mapped("carrier_info_id")
+            carrier_recs = invoice.picking_ids.mapped("carrier_info_id").filtered(
+                lambda x: not x.is_dummy
+            )
             if carrier_recs:
                 invoice.carrier_info_name = ", ".join(x.name for x in carrier_recs)
                 tracking_urls = carrier_recs.mapped("tracking_url")

--- a/account_invoice_validate_send_email/models/stock_carrier_info.py
+++ b/account_invoice_validate_send_email/models/stock_carrier_info.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockCarrierInfo(models.Model):
+    _inherit = "stock.carrier.info"
+
+    is_dummy = fields.Boolean(
+        "Dummy Carrier",
+        help="If selected, the carrier info will be ignored in email content "
+        "preparation at the invoice validation.",
+    )

--- a/account_invoice_validate_send_email/views/stock_carrier_info_views.xml
+++ b/account_invoice_validate_send_email/views/stock_carrier_info_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_stock_carrier_info_form">
+        <field name="name">stock.carrier.info.form</field>
+        <field name="model">stock.carrier.info</field>
+        <field name="inherit_id" ref="stock_carrier_info.view_stock_carrier_info_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='tracking_url']" position="after">
+                <field name="is_dummy"/>
+            </xpath>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="view_stock_carrier_info_tree">
+        <field name="name">stock.carrier.info.tree</field>
+        <field name="model">stock.carrier.info</field>
+        <field name="inherit_id" ref="stock_carrier_info.view_stock_carrier_info_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='tracking_url']" position="after">
+                <field name="is_dummy"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
[1782](https://www.quartile.co/web#view_type=form&model=project.task&id=1782&active_id=1782&menu_id=)

This update adds the option to ignore the carrier info record in email content preparation in invoice validation.
