### PR TITLE
[2135][FIX] sale_automatic_workflow_propose

### DIFF
--- a/sale_automatic_workflow_propose/__manifest__.py
+++ b/sale_automatic_workflow_propose/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "AGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.1.1",
     "depends": ["sale_automatic_workflow", "sale_user_type"],
     "data": ["views/sale_workflow_process_views.xml"],
     "installable": True,

--- a/sale_automatic_workflow_propose/models/sale_order.py
+++ b/sale_automatic_workflow_propose/models/sale_order.py
@@ -8,21 +8,27 @@ from odoo import api, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    def _update_vals(self, vals):
-        if vals.get("user_type"):
-            process = self.env["sale.workflow.process"].search(
-                [("apply_to", "=", vals["user_type"])]
-            )[:1]
-            if process:
-                vals["workflow_process_id"] = process.id
-        return vals
+    @api.model
+    def _get_workflow_process(self, user_type):
+        return self.env["sale.workflow.process"].search([("apply_to", "=", user_type)])[
+            :1
+        ]
 
     @api.model
     def create(self, vals):
-        vals = self._update_vals(vals)
-        return super(SaleOrder, self).create(vals)
+        order = super(SaleOrder, self).create(vals)
+        if not order.user_type:
+            return order
+        process = self._get_workflow_process(order.user_type)
+        if process:
+            order.workflow_process_id = process.id
+        return order
 
     @api.multi
     def write(self, vals):
-        vals = self._update_vals(vals)
+        if not vals.get("user_type"):
+            return super(SaleOrder, self).write(vals)
+        process = self._get_workflow_process(vals.get("user_type"))
+        if process:
+            vals["workflow_process_id"] = process.id
         return super(SaleOrder, self).write(vals)


### PR DESCRIPTION
[2135](https://www.quartile.co/web?debug=1#id=2135&action=771&model=project.task&view_type=form&menu_id=505)

Before this fix, workflow_process_id was not being proposed when sales order was created
with user logged in, because the logic was relying on the assumption that 'user_type' would
be available in vals, which wasn't the case due to the sequence of the create() extensions.