### PR TITLE
st1 [2726][FIX] website_sale_affiliate_a8

### DIFF
--- a/sale_automatic_workflow_propose/__manifest__.py
+++ b/sale_automatic_workflow_propose/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "AGPL-3",
     "author": "Quartile Limited",
     "website": "https://www.quartile.co",
-    "version": "10.0.1.1.1",
+    "version": "10.0.1.1.2",
     "depends": ["sale_automatic_workflow", "sale_user_type"],
     "data": ["views/sale_workflow_process_views.xml"],
     "installable": True,

--- a/website_sale_affiliate_a8/README.rst
+++ b/website_sale_affiliate_a8/README.rst
@@ -38,9 +38,12 @@ Configuration
 =============
 
 For the initial setup, go to *Settings > Technical > System Parameters* and update 3 parameters like below:
+
 - affiliate.service.name: Affiliate service provider's name
 - affiliate.pid: Program ID issued by affiliate vendor
 - affiliate.script.src: URL to the conversion acquisition script
+
+See https://document.a8.net/ec/trackingGuide-ja.html for hte tag specification.
 
 Bug Tracker
 ===========

--- a/website_sale_affiliate_a8/models/sale_order.py
+++ b/website_sale_affiliate_a8/models/sale_order.py
@@ -25,7 +25,7 @@ class SaleOrder(models.Model):
                     1 - (line.discount or 0.0) / 100.0
                 )
             item_dict = {
-                "code": str(line.product_id.default_code),
+                "code": line.product_id.default_code or "",
                 "price": unit_price_total,
                 "quantity": line.product_uom_qty,
             }

--- a/website_sale_affiliate_a8/readme/CONFIGURE.rst
+++ b/website_sale_affiliate_a8/readme/CONFIGURE.rst
@@ -1,4 +1,7 @@
 For the initial setup, go to *Settings > Technical > System Parameters* and update 3 parameters like below:
+
 - affiliate.service.name: Affiliate service provider's name
 - affiliate.pid: Program ID issued by affiliate vendor
 - affiliate.script.src: URL to the conversion acquisition script
+
+See https://document.a8.net/ec/trackingGuide-ja.html for hte tag specification.

--- a/website_sale_affiliate_a8/static/description/index.html
+++ b/website_sale_affiliate_a8/static/description/index.html
@@ -390,10 +390,13 @@ ul.auto-toc {
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#id1">Configuration</a></h1>
-<p>For the initial setup, go to <em>Settings &gt; Technical &gt; System Parameters</em> and update 3 parameters like below:
-- affiliate.service.name: Affiliate service provider’s name
-- affiliate.pid: Program ID issued by affiliate vendor
-- affiliate.script.src: URL to the conversion acquisition script</p>
+<p>For the initial setup, go to <em>Settings &gt; Technical &gt; System Parameters</em> and update 3 parameters like below:</p>
+<ul class="simple">
+<li>affiliate.service.name: Affiliate service provider’s name</li>
+<li>affiliate.pid: Program ID issued by affiliate vendor</li>
+<li>affiliate.script.src: URL to the conversion acquisition script</li>
+</ul>
+<p>See <a class="reference external" href="https://document.a8.net/ec/trackingGuide-ja.html">https://document.a8.net/ec/trackingGuide-ja.html</a> for hte tag specification.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>


### PR DESCRIPTION
[2726](https://www.quartile.co/web?#id=2726&action=771&active_id=1758&model=project.task&view_type=form&menu_id=505)

Remove unnecessary str() encoding on the product default_code field to avoid
UnicodeEncodeError when the value involves non-ascii characters.
