### PR TITLE
15st1 [2768][IMP] sale_order_line_delivery_date: hide delivery_date by default

### DIFF
--- a/sale_order_line_delivery_date/views/sale_order_views.xml
+++ b/sale_order_line_delivery_date/views/sale_order_views.xml
@@ -15,7 +15,7 @@
                 expr="//field[@name='order_line']/tree/field[@name='route_id']"
                 position="after"
             >
-                <field name="delivery_date" />
+                <field name="delivery_date" optional="hide" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
[2768](https://www.quartile.co/web?debug=1#id=2768&action=771&model=project.task&view_type=form&menu_id=505)

Currently facing with a mysterious JS issue (TypeError: defaultDate() Could not parse date parameter: NaN) and it does not help if there is no option to hide the field, therefore added optional='hide' to the delivery_date field.