### PR TITLE
[4040][FIX] account_tax_round_down: Add signature

### DIFF
--- a/account_tax_round_down/models/account_move.py
+++ b/account_tax_round_down/models/account_move.py
@@ -8,12 +8,15 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     # For journal entries
-    def _recompute_tax_lines(self, recompute_tax_base_amount=False):
+    def _recompute_tax_lines(
+        self, recompute_tax_base_amount=False, tax_rep_lines_to_recompute=None
+    ):
         self.ensure_one()
         if self.company_id.need_tax_round_down:
             self = self.with_context(rounding_method="DOWN")
         return super()._recompute_tax_lines(
-            recompute_tax_base_amount=recompute_tax_base_amount
+            recompute_tax_base_amount=recompute_tax_base_amount,
+            tax_rep_lines_to_recompute=tax_rep_lines_to_recompute,
         )
 
     # For invoice form and print total presentation.


### PR DESCRIPTION
[4040](https://www.quartile.co/web#menu_id=505&cids=3&action=1457&model=project.task&view_type=form&id=4040)

This PR addresses a TypeError(`TypeError: _recompute_tax_lines() got an unexpected keyword argument 'tax_rep_lines_to_recompute'`) that was occurring when we try to validate account.move records, because there is mismatch in the method signature of the overridden _recompute_tax_lines method in a subclass. 

The parent class method was expecting an additional argument `tax_rep_lines_to_recompute`, which was not accounted for in the subclass.

odoo/odoo code
https://github.com/odoo/odoo/blob/23e6f7c0f8b793d4aa30df8a65b29def516ecb87/addons/account/models/account_move.py#L690

