### PR TITLE
[15.0][5906][FIX] website_form_other_information_message: use auto_comment message type instead of comment

### DIFF
--- a/website_form_other_information_message/controllers/form.py
+++ b/website_form_other_information_message/controllers/form.py
@@ -16,7 +16,7 @@ class WebsiteForm(form.WebsiteForm):
                 values = {
                     "body": record[default_field.name],
                     "model": model.model,
-                    "message_type": "comment",
+                    "message_type": "auto_comment",
                     "res_id": record.id,
                 }
                 request.env["mail.message"].with_user(SUPERUSER_ID).create(values)

--- a/website_form_other_information_message/static/description/index.html
+++ b/website_form_other_information_message/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {


### PR DESCRIPTION
For the other information email, we should use `auto_comment` instead of `comment` for message type since the message was generated from website form by `odoobot`.
This will also fix the incompatibility with `mail_message_restrict`.

[5906](https://www.quartile.co/web#id=5906&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)