### PR TITLE
[6902][IMP] website_auth_view_mi7: align register button with login button

### DIFF
--- a/website_auth_view_mi7/README.rst
+++ b/website_auth_view_mi7/README.rst
@@ -24,10 +24,10 @@ Website Login/Signup Page Adjustments
 
 This module does the following:
 
--  Changes the presentation of the signup, login and password reset
-   pages (for the better).
--  Adds custom message fields in the website to show them in the
-   above-mentioned pages.
+- Changes the presentation of the signup, login and password reset pages
+  (for the better).
+- Adds custom message fields in the website to show them in the
+  above-mentioned pages.
 
 **Table of contents**
 

--- a/website_auth_view_mi7/static/description/index.html
+++ b/website_auth_view_mi7/static/description/index.html
@@ -371,8 +371,8 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/qrtl/mi7-custom/tree/15.0/website_auth_view_mi7"><img alt="qrtl/mi7-custom" src="https://img.shields.io/badge/github-qrtl%2Fmi7--custom-lightgray.png?logo=github" /></a></p>
 <p>This module does the following:</p>
 <ul class="simple">
-<li>Changes the presentation of the signup, login and password reset
-pages (for the better).</li>
+<li>Changes the presentation of the signup, login and password reset pages
+(for the better).</li>
 <li>Adds custom message fields in the website to show them in the
 above-mentioned pages.</li>
 </ul>

--- a/website_auth_view_mi7/views/templates.xml
+++ b/website_auth_view_mi7/views/templates.xml
@@ -3,12 +3,14 @@
 
     <!-- Website header: show the signup link next to the login link -->
     <template id="user_sign_up" inherit_id="portal.user_sign_in" name="User Sign Up">
-        <xpath expr="//a" position="before">
-            <a
-                t-attf-href="/web/signup"
-                t-attf-class="#{_link_class}"
-                style="margin-right: 8px;"
-            >Register</a>
+        <xpath expr="//li" position="before">
+            <li
+                groups="base.group_public"
+                t-attf-class="#{_item_class} o_no_autohide_item"
+            >
+                <a t-attf-href="/web/signup" t-attf-class="#{_link_class}">Register</a>
+            </li>
+            <t t-set="_item_class" t-valuef="nav-item" />
         </xpath>
     </template>
 


### PR DESCRIPTION
[QT6902](https://www.quartile.co/web#id=6902&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

This places the register button and sign in button in separate li elements so that these button sit side by side.

<img width="639" height="271" alt="image" src="https://github.com/user-attachments/assets/0ca32f77-899f-417a-8e0f-092ed272bbcd" />
